### PR TITLE
action[game]: adding restitution to prevent bounceback

### DIFF
--- a/memory-rooms/Scenes/Nodes/PlayerNode.swift
+++ b/memory-rooms/Scenes/Nodes/PlayerNode.swift
@@ -21,6 +21,7 @@ class Player: SKSpriteNode {
         self.physicsBody?.categoryBitMask = 1
         self.physicsBody?.collisionBitMask = 2
         self.physicsBody?.contactTestBitMask = 2
+        self.physicsBody?.restitution = 0.0
 
         loadWalkTextures(direction: "Fwd")
     }

--- a/memory-rooms/Scenes/Nodes/WallNode.swift
+++ b/memory-rooms/Scenes/Nodes/WallNode.swift
@@ -17,6 +17,8 @@ class Wall: SKSpriteNode {
         self.physicsBody?.categoryBitMask = 2
         self.physicsBody?.collisionBitMask = 1
         self.physicsBody?.contactTestBitMask = 1
+        self.physicsBody?.restitution = 0.0
+
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Disabled bounceback from wall using physicsBody's built-in restitution property so that we don't have to deal with the weird size effects of bounciness 